### PR TITLE
Full job url for UniProtUpdate in Jenkins

### DIFF
--- a/cosmic-update.jenkinsfile
+++ b/cosmic-update.jenkinsfile
@@ -18,7 +18,7 @@ pipeline
 			{
 				script
 				{
-					utils.checkUpstreamBuildsSucceeded("UniProtUpdate")
+					utils.checkUpstreamBuildsSucceeded("Pre-Slice/job/UniProtUpdate")
 				}
 			}
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>org.reactome.release</groupId>
 			<artifactId>release-common-lib</artifactId>
-			<version>1.2.1-SNAPSHOT</version>
+			<version>1.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.beust</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>org.reactome.release</groupId>
 			<artifactId>release-common-lib</artifactId>
-			<version>1.2.1</version>
+			<version>1.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.beust</groupId>


### PR DESCRIPTION
@SolomonShorser-OICR  The `checkUpstreamBuildsSucceeded` method requires the specific Jenkins repository path... which is a bit annoying. There wasn't anyway for you to know this ahead of time, but if you look at the URL of the UniProtUpdate project on the Jenkins server, its within `${releaseVersion}/Pre-Slice/job/`